### PR TITLE
Add REST API example for fetching pool details

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI, HTTPException
+from dataclasses import asdict
+from sugar.chains import AsyncOPChain
+
+app = FastAPI()
+
+_chain: AsyncOPChain | None = None
+
+@app.on_event("startup")
+async def startup_event():
+    global _chain
+    _chain = AsyncOPChain()
+    await _chain.__aenter__()
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    if _chain is not None:
+        await _chain.__aexit__(None, None, None)
+
+@app.get("/pool/{address}")
+async def get_pool(address: str):
+    if _chain is None:
+        raise HTTPException(status_code=500, detail="Chain not initialized")
+    pool = await _chain.get_pool_by_address(address)
+    if pool is None:
+        raise HTTPException(status_code=404, detail="Pool not found")
+    return asdict(pool)
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("api_server:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- implement a simple FastAPI server
- endpoint `/pool/{address}` returns full pool details

## Testing
- `uvicorn api_server:app --port 8000` *(fails: command not found)*